### PR TITLE
add ability to specify airflow environs for config

### DIFF
--- a/charts/airflow/templates/_helpers.yaml
+++ b/charts/airflow/templates/_helpers.yaml
@@ -1,13 +1,30 @@
 {{/* Airflow environment variables */}}
 {{- define "airflow_environment" }}
-  # Dynamically create environment variables
+  # Dynamically created environment variables
   {{- range $i, $config := .Values.env }}
   - name: {{ $config.name }}
     value: {{ $config.value | quote }}
   {{- end }}
-  # Hard-coded environment variables.
-  # We need to use the release name, so we can't
-  # set it in values.yaml.
+  # Hard Coded Airflow Envs
+  - name: AIRFLOW__CORE__EXECUTOR
+    value: "CeleryExecutor"
+  - name: AIRFLOW__SCHEDULER__STATSD_ON
+    value: "True"
+  - name: AIRFLOW__SCHEDULER__STATSD_PORT
+    value: "9125"
+  - name: AIRFLOW__SCHEDULER__STATSD_PREFIX
+    value: "airflow"
+  - name: ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION
+    value: "15"
+  # Dynamically created secret envs
+  {{- range $i, $config := .Values.secret }}
+  - name: {{ $config.name }}
+    valueFrom:
+      secretKeyRef:
+        name: {{ $config.value }}
+        key:  value
+  {{- end}}
+  # Hard Coded Secret Envs
   - name: AIRFLOW__SCHEDULER__STATSD_HOST
     value: "{{ .Release.Name }}-statsd"
   - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -30,16 +30,6 @@ workers:
 
 # Environment variables for all airflow containers
 env:
-  - name: AIRFLOW__CORE__EXECUTOR
-    value: "CeleryExecutor"
-  - name: AIRFLOW__SCHEDULER__STATSD_ON
-    value: "True"
-  - name: AIRFLOW__SCHEDULER__STATSD_PORT
-    value: "9125"
-  - name: AIRFLOW__SCHEDULER__STATSD_PREFIX
-    value: "airflow"
-  - name: ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION
-    value: "15"
 
 # Astronomer Airflow database config
 data:

--- a/config.tpl.yaml
+++ b/config.tpl.yaml
@@ -8,3 +8,8 @@ global:
   baseDomain:
   tlsSecret:
   acme: false
+
+# Airflow config overrides
+airflow:
+  env:
+  secret:


### PR DESCRIPTION
this commit
  - adds placeholders in config.tpl.yaml to expose settings to user
  - adds ability to pass env configurations to airflow via normal envs and secrets
