### PR TITLE
Disable nginx if no baseDomain is set

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -10,4 +10,4 @@ dependencies:
     condition: global.modules.clickstream.enabled
   - name: nginx
     version: 0.0.0
-    condition: global.modules.nginx.enabled
+    condition: global.modules.nginx.enabled,global.baseDomain


### PR DESCRIPTION
There is no need for nginx if we don't set a baseDomain. This PR 
- leverages multiple conditions on the conditions attribute of requirements.yaml file to achieve that
- closes #12 