### PR TITLE
Passthrough storageClassName to stateful sets

### DIFF
--- a/charts/airflow/templates/workers/worker-statefulset.yaml
+++ b/charts/airflow/templates/workers/worker-statefulset.yaml
@@ -62,6 +62,9 @@ spec:
     - metadata:
         name: logs
       spec:
+        {{- if .Values.workers.persistence.storageClassName }}
+        storageClassName: {{ .Values.workers.persistence.storageClassName }}
+        {{- end }}
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -22,6 +22,9 @@ workers:
     # Enable persistent volumes
     enabled: false
 
+    # If using a custom storageClass, pass name ref to all statefulSets here
+    storageClassName:
+
     # Volume size for worker StatefulSet
     size: 10Gi
 

--- a/values.yaml
+++ b/values.yaml
@@ -52,3 +52,5 @@ airflow:
     # Enable persistence to keep logs around between deploys
     persistence:
       enabled: true
+      # If using a custom storageClass, pass name ref to all statefulSets here
+      storageClassName:


### PR DESCRIPTION
@schnie Is this what you had in mind? Is the use case here if a user defines a storageClass in the charts and wants to point to defined storageClass?

If ok, this PR

- closes #14 