### PR TITLE
Support GKE beta internal load balancer

### DIFF
--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -13,11 +13,11 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   type: LoadBalancer
-  {{- if .Values.global.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.global.loadBalancerIP }}
+  {{- if .Values.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.loadBalancerIP }}
   {{- end }}
-  {{- if .Values.global.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges: {{ .Values.global.loadBalancerSourceRanges }}
+  {{- if .Values.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.loadBalancerSourceRanges }}
   {{- end }}
   {{- if .Values.preserveSourceIP }}
   externalTrafficPolicy: "Local"

--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -16,6 +16,9 @@ spec:
   {{- if .Values.global.loadBalancerIP }}
   loadBalancerIP: {{ .Values.global.loadBalancerIP }}
   {{- end }}
+  {{- if .Values.global.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{ .Values.global.loadBalancerSourceRanges }}
+  {{- end }}
   {{- if .Values.preserveSourceIP }}
   externalTrafficPolicy: "Local"
   {{- end }}

--- a/config.tpl.yaml
+++ b/config.tpl.yaml
@@ -4,12 +4,14 @@
 
 # Global overrides
 global:
-  loadBalancerIP:
-  loadBalancerSourceRanges:
-  - 0.0.0.0/0
   baseDomain:
   tlsSecret:
   acme: false
+
+nginx:
+  loadBalancerIP:
+  loadBalancerSourceRanges:
+  - 0.0.0.0/0
 
 # Airflow config overrides
 airflow:

--- a/config.tpl.yaml
+++ b/config.tpl.yaml
@@ -5,6 +5,8 @@
 # Global overrides
 global:
   loadBalancerIP:
+  loadBalancerSourceRanges:
+  - 0.0.0.0/0
   baseDomain:
   tlsSecret:
   acme: false

--- a/values.yaml
+++ b/values.yaml
@@ -39,11 +39,16 @@ global:
     nginx:
       enabled: true
 
-      # IP address the nginx ingress should bind to
-      loadBalancerIP:
 
-      # Used to restrict IPs which can reach the nginx ingress
-      loadBalancerSourceRanges:
+################################
+## Nginx configuration
+################################
+nginx:
+  # IP address the nginx ingress should bind to
+  loadBalancerIP:
+
+  # Used to restrict IPs which can reach the nginx ingress
+  loadBalancerSourceRanges:
 
 
 ################################

--- a/values.yaml
+++ b/values.yaml
@@ -5,6 +5,9 @@ global:
   # IP address the nginx ingress should bind to
   loadBalancerIP:
 
+  # TODO
+  loadBalancerSourceRanges:
+
   # Base domain for all subdomains exposed through ingress
   baseDomain:
 

--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@ global:
   # IP address the nginx ingress should bind to
   loadBalancerIP:
 
-  # TODO
+  # Used to restrict IPs which can reach the nginx ingress
   loadBalancerSourceRanges:
 
   # Base domain for all subdomains exposed through ingress

--- a/values.yaml
+++ b/values.yaml
@@ -2,12 +2,6 @@
 ## Astronomer global configuration
 #################################
 global:
-  # IP address the nginx ingress should bind to
-  loadBalancerIP:
-
-  # Used to restrict IPs which can reach the nginx ingress
-  loadBalancerSourceRanges:
-
   # Base domain for all subdomains exposed through ingress
   baseDomain:
 
@@ -44,6 +38,12 @@ global:
     # Enable NGINX ingress module
     nginx:
       enabled: true
+
+      # IP address the nginx ingress should bind to
+      loadBalancerIP:
+
+      # Used to restrict IPs which can reach the nginx ingress
+      loadBalancerSourceRanges:
 
 
 ################################


### PR DESCRIPTION
@andscoop and I deployed these changes today successfully to restrict the ingress layer on [redacted]'s beta GKE dev cluster to an IP range like `1.2.3.4/28`.

Initially we thought changes might need to be made to `public-ingress.yaml` and `protected-ingress.yaml` as well for this to work... but maybe it works implicitly because they use the nginx service?