### PR TITLE
Add PodDisruptionBudget to scheduler

### DIFF
--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -13,6 +13,11 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
   selector:
     matchLabels:
       tier: airflow

--- a/charts/airflow/templates/scheduler/scheduler-poddisruptionbudget.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-poddisruptionbudget.yaml
@@ -14,4 +14,4 @@ spec:
       tier: airflow
       component: scheduler
       release: {{ .Release.Name }}
-{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{ toYaml .Values.scheduler.podDisruptionBudget | indent 2 }}

--- a/charts/airflow/templates/scheduler/scheduler-poddisruptionbudget.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-poddisruptionbudget.yaml
@@ -1,0 +1,17 @@
+kind: PodDisruptionBudget
+apiVersion: policy/v1beta1
+metadata:
+  name: {{ .Release.Name }}-pdb
+  labels:
+    tier: airflow
+    component: scheduler
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      tier: airflow
+      component: scheduler
+      release: {{ .Release.Name }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -31,8 +31,13 @@ workers:
   # Grace period for tasks to finish after SIGTERM is sent from kubernetes
   terminationGracePeriodSeconds: 600
 
-podDisruptionBudget:
-  maxUnavailable: 1
+# Airflow scheduler settings
+scheduler:
+
+  podDisruptionBudget:
+
+    # Ensure we have one replica always running
+    maxUnavailable: 1
 
 # Environment variables for all airflow containers
 env:

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -31,6 +31,9 @@ workers:
   # Grace period for tasks to finish after SIGTERM is sent from kubernetes
   terminationGracePeriodSeconds: 600
 
+podDisruptionBudget:
+  maxUnavailable: 1
+
 # Environment variables for all airflow containers
 env:
 


### PR DESCRIPTION
This ensures that the scheduler will never have less than one instance running during disruptions. Should protect in situations where resources are tight.