### PR TITLE
Merged secret config, auto create houston secret

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -8,3 +8,7 @@
 {{ printf "\"tlsSecret\":\"%v\"" (print .Values.global.tlsSecret | toString | replace "<nil>" "") -}}
 {{ print "}" -}}
 {{- end }}
+
+{{- define "houston_jwt_passphrase" }}
+  {{- randAlphaNum 32 }}
+{{- end }}

--- a/charts/astronomer/templates/houston/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/houston-deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: JWT_PASSPHRASE
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.data.houstonJwtPassphraseSecret }}
+                  name: {{ .Release.Name }}-houston-jwt-passphrase
                   key: passphrase
             - name: HOUSTON_POSTGRES_URI
               valueFrom:

--- a/charts/astronomer/templates/houston/houston-secrets.yaml
+++ b/charts/astronomer/templates/houston/houston-secrets.yaml
@@ -1,0 +1,15 @@
+################################
+## Astronomer Houston Secrets
+#################################
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-houston-jwt-passphrase
+  labels:
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  passphrase: {{ template "houston_jwt_passphrase" . }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -13,9 +13,8 @@ images:
 
 # Astronomer platform config
 data:
-  houstonJwtPassphraseSecret: "houston-jwt-passphrase"
   houstonDatabaseSecret: "houston-database"
-  airflowDatabaseSecret: "airflow-database"
+  airflowDatabaseSecret: "houston-database"
   airflowRedisSecret: "airflow-redis"
 
 # Enable persistence to keep registry data between deploys


### PR DESCRIPTION
Merged the database secrets for houston and airflow by default
Houston will now auto generate the jwt passphrase secret so it doesn’t need to be manually created