### PR TITLE
Add fernet key to airflow environment variables

### DIFF
--- a/charts/airflow/templates/_helpers.yaml
+++ b/charts/airflow/templates/_helpers.yaml
@@ -44,6 +44,11 @@
       secretKeyRef:
         name: {{ .Values.data.airflowBrokerSecret }}
         key: connection
+  - name: AIRFLOW__CORE__FERNET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Release.Name }}-fernet-key
+        key: fernet-key
 {{- end }}
 
 {{ define "airflow_url" -}}
@@ -60,4 +65,8 @@
 
 {{ define "prometheus_url" -}}
 {{ .Release.Name }}-prometheus.{{ .Values.global.baseDomain }}
+{{- end }}
+
+{{ define "fernet_key" -}}
+{{ (randAlphaNum 32 | b64enc) | b64enc }}
 {{- end }}

--- a/charts/airflow/templates/secrets.yaml
+++ b/charts/airflow/templates/secrets.yaml
@@ -1,0 +1,14 @@
+################################
+## Airflow Secrets
+#################################
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-fernet-key
+  labels:
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  fernet-key: {{ template "fernet_key" . }}


### PR DESCRIPTION
This adds a new kubernetes secret, tied to the airflow chart release that contains an automatically generated 32-byte string. This string is provided to the airflow containers as an environment variable. This closes #34.