### PR TITLE
Use helper methods to get image names

### DIFF
--- a/charts/airflow/templates/_helpers.yaml
+++ b/charts/airflow/templates/_helpers.yaml
@@ -70,3 +70,19 @@
 {{ define "fernet_key" -}}
 {{ (randAlphaNum 32 | b64enc) | b64enc }}
 {{- end }}
+
+{{ define "airflow_image" -}}
+{{ .Values.images.airflow }}:{{ or .Values.global.imageTag .Values.imageTag }}
+{{- end }}
+
+{{ define "statsd_image" -}}
+{{ .Values.images.statsd }}:{{ or .Values.global.imageTag .Values.imageTag }}
+{{- end }}
+
+{{ define "prometheus_image" -}}
+{{ .Values.images.prometheus }}:{{ or .Values.global.imageTag .Values.imageTag }}
+{{- end }}
+
+{{ define "grafana_image" -}}
+{{ .Values.images.grafana }}:{{ or .Values.global.imageTag .Values.imageTag }}
+{{- end }}

--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}-flower
-          image: {{ .Values.images.airflow }}
+          image: {{- include "airflow_image" . | indent 1 }}
           args: ["airflow", "flower"]
           ports:
             - name: flower-ui

--- a/charts/airflow/templates/grafana/grafana-deployment.yaml
+++ b/charts/airflow/templates/grafana/grafana-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: {{ .Release.Name }}-grafana
-          image: {{ .Values.images.grafana }}
+          image: {{- include "grafana_image" . | indent 1 }}
           ports:
             - name: grafana-ui
               containerPort: 3000

--- a/charts/airflow/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/airflow/templates/prometheus/prometheus-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: {{ .Release.Name }}-prometheus
-          image: {{ .Values.images.prometheus }}
+          image: {{- include "prometheus_image" . | indent 1 }}
           args:
             - "--config.file=/etc/prometheus/config/kubernetes.yaml"
             - "--storage.tsdb.path={{ .Values.prometheus.dataDir }}"

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}-scheduler
-          image: {{ .Values.images.airflow }}
+          image: {{- include "airflow_image" . | indent 1 }}
           args: ["airflow", "scheduler"]
           env:
           {{- include "airflow_environment" . | indent 10 }}

--- a/charts/airflow/templates/statsd/statsd-deployment.yaml
+++ b/charts/airflow/templates/statsd/statsd-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: {{ .Release.Name }}-statsd
-          image: {{ .Values.images.statsdExporter }}
+          image: {{- include "statsd_image" . | indent 1 }}
           args:
             - "-statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
           ports:

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}-webserver
-          image: {{ .Values.images.airflow }}
+          image: {{- include "airflow_image" . | indent 1 }}
           args: ["airflow", "webserver"]
           ports:
             - name: webserver-ui

--- a/charts/airflow/templates/workers/worker-statefulset.yaml
+++ b/charts/airflow/templates/workers/worker-statefulset.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Release.Name }}-worker
-          image: {{ .Values.images.airflow }}
+          image: {{- include "airflow_image" . | indent 1 }}
           args: ["airflow", "worker"]
           ports:
             - name: worker-logs

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -8,10 +8,12 @@ gid: 101
 
 # Astronomer Airflow images
 images:
-  airflow: astronomerinc/ap-airflow:0.2.0
-  statsdExporter: astronomerinc/ap-statsd-exporter:0.2.0
-  prometheus: astronomerinc/ap-prometheus:0.2.0
-  grafana: astronomerinc/ap-grafana:0.2.0
+  airflow: astronomerinc/ap-airflow
+  statsd: astronomerinc/ap-statsd-exporter
+  prometheus: astronomerinc/ap-prometheus
+  grafana: astronomerinc/ap-grafana
+
+imageTag: 0.2.0
 
 # Airflow Worker Config
 workers:

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -12,3 +12,15 @@
 {{- define "houston_jwt_passphrase" }}
   {{- randAlphaNum 32 | b64enc }}
 {{- end }}
+
+{{ define "commander_image" -}}
+{{ .Values.images.commander }}:{{ or .Values.global.imageTag .Values.imageTag }}
+{{- end }}
+
+{{ define "houston_image" -}}
+{{ .Values.images.houston }}:{{ or .Values.global.imageTag .Values.imageTag }}
+{{- end }}
+
+{{ define "registry_image" -}}
+{{ .Values.images.registry }}:{{ or .Values.global.imageTag .Values.imageTag }}
+{{- end }}

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         runAsUser: {{ .Values.uid }}
       containers:
         - name: {{ .Release.Name }}-commander
-          image: {{ .Values.images.commander }}
+          image: {{- include "commander_image" . | indent 1 }}
           ports:
             - name: commander-http
               containerPort: 8880

--- a/charts/astronomer/templates/houston/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/houston-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         runAsUser: {{ .Values.uid }}
       containers:
         - name: {{ .Release.Name }}-houston
-          image: {{ .Values.images.houston }}
+          image: {{- include "houston_image" . | indent 1 }}
           ports:
             - name: houston-http
               containerPort: 8870

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: {{ .Release.Name }}-registry
-          image: {{ .Values.images.registry }}
+          image: {{- include "registry_image" . | indent 1 }}
           volumeMounts:
             - name: registry-config-volume
               mountPath: /etc/docker/registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -7,9 +7,11 @@ uid: 100
 
 # Images for pilot
 images:
-  commander: astronomerinc/ap-commander:0.2.0
-  registry: astronomerinc/ap-registry:0.2.0
-  houston: astronomerinc/ap-houston-api:0.2.0
+  commander: astronomerinc/ap-commander
+  registry: astronomerinc/ap-registry
+  houston: astronomerinc/ap-houston-api
+
+imageTag: 0.2.0
 
 # Astronomer platform config
 data:

--- a/charts/nginx/templates/_helpers.tpl
+++ b/charts/nginx/templates/_helpers.tpl
@@ -30,3 +30,11 @@ Create chart name and version as used by the chart label.
 {{- define "chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{ define "nginx_image" -}}
+{{ .Values.images.nginx }}:{{ or .Values.global.imageTag .Values.imageTag }}
+{{- end }}
+
+{{ define "default_backend_image" -}}
+{{ .Values.images.defaultBackend }}:{{ or .Values.global.imageTag .Values.imageTag }}
+{{- end }}

--- a/charts/nginx/templates/nginx-deployment-default.yaml
+++ b/charts/nginx/templates/nginx-deployment-default.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
         - name: {{ .Release.Name }}-default-backend
-          image: {{ .Values.images.defaultBackend }}
+          image: {{- include "default_backend_image" . | indent 1 }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-nginx-ingress-controller
       containers:
         - name: {{ .Release.Name }}-nginx
-          image: {{ .Values.images.nginxIngress }}
+          image: {{- include "nginx_image" . | indent 1 }}
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ .Release.Namespace }}/{{ .Release.Name }}-nginx-default-backend

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -2,8 +2,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 images:
-  nginxIngress: astronomerinc/ap-nginx:0.2.0
-  defaultBackend: astronomerinc/ap-default-backend:0.2.0
+  nginx: astronomerinc/ap-nginx
+  defaultBackend: astronomerinc/ap-default-backend
+
+imageTag: 0.2.0
 
 # IP address the nginx ingress should bind to
 loadBalancerIP:


### PR DESCRIPTION
This also separates out the image names from the image tags, allowing us to override just the tag at a global level to quickly iterate on new builds during development.

This is a potential fix for #36. It allows us to set `global.imageTag` at install time and have it propagate to any sub-charts being installed. If installing just a single chart you can set `imageTag` at install time.

After we push an official release, we still need to update the individual `imageTag` values in each sub-chart.