### PR TITLE
Remove second values for tier

### DIFF
--- a/charts/airflow/templates/statsd/statsd-service.yaml
+++ b/charts/airflow/templates/statsd/statsd-service.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     tier: monitoring
     component: statsd
-    tier: monitoring
     release: {{ .Release.Name }}
     workspace: {{ .Values.workspace }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/airflow/templates/workers/worker-service.yaml
+++ b/charts/airflow/templates/workers/worker-service.yaml
@@ -8,7 +8,6 @@ metadata:
   labels:
     tier: airflow
     component: worker
-    tier: airflow-core
     release: {{ .Release.Name }}
     workspace: {{ .Values.workspace }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"


### PR DESCRIPTION
I noticed the `tier` key was defined twice in these two services.  For statsd-service, the two values were the same.  For worker-service, they were different, so I kept the one that was consistent with everywhere else (didn't see `tier: airflow-core` used elsewhere).