### PR TITLE
Nginx upgrades

### DIFF
--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -61,3 +61,26 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+   {{- if eq (default .Values.global.antiAffinity .Values.antiAffinity) "hard" }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  tier: nginx
+                  component: ingress-controller
+                  release: {{ .Release.Name }}
+      {{- else if eq (default .Values.global.antiAffinity .Values.antiAffinity) "soft" }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  tier: nginx
+                  component: ingress-controller
+                  release: {{ .Release.Name }}
+    {{- end }}

--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -11,6 +11,9 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+  annotations:
+    # AWS annotations
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 spec:
   type: LoadBalancer
   {{- if .Values.loadBalancerIP }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,6 +9,9 @@ images:
     name: astronomerinc/ap-default-backend
     tag: 0.3.0
 
+# AntiAffinity can be "hard" or "soft"
+antiAffinity: "soft"
+
 # IP address the nginx ingress should bind to
 loadBalancerIP:
 


### PR DESCRIPTION
This PR upgrades our NGINX deployment so that it's replicas can be scaled up, and ensure that no two replicas will land on the same node.

It also adds support for AWS NLB in the NGINX Service.