### PR TITLE
Fix broken airflow target

### DIFF
--- a/charts/airflow/templates/statsd/statsd-service.yaml
+++ b/charts/airflow/templates/statsd/statsd-service.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     prometheus.io/scrape: 'true'
-    prometheus.io/port: '9102'
+    prometheus.io/port: {{ .Values.ports.statsdScrape }}
 spec:
   type: NodePort
   selector:

--- a/charts/prometheus/templates/prometheus-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-configmap.yaml
@@ -20,7 +20,6 @@ data:
 
     scrape_configs:
       - job_name: airflow
-        scrape_interval: 2s
         kubernetes_sd_configs:
           - role: service
             namespaces:
@@ -30,6 +29,11 @@ data:
           - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
             action: keep
             regex: true
+          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+            action: replace
+            regex: ([^:]+)(?::\d+)?;(\d+)
+            replacement: $1:$2
+            target_label: __address__
 
       - job_name: kubernetes-nodes-cadvisor
         scrape_interval: 10s


### PR DESCRIPTION
Our prometheus config wasn't looking at the prometheus.io/port annotation and therefore falling back to look at defined ports on the service. Prometheus was attempting to scrape both ports defined on the statsd service, only one of which exposes metrics. The other port is for ingestion, which was always timing out and marked DOWN in the prometheus targets list. This commit should fix that. Also falling back to global 5s scrape.