### PR TITLE
Upgrade grafana to latest

### DIFF
--- a/charts/grafana/templates/grafana-configmap.yaml
+++ b/charts/grafana/templates/grafana-configmap.yaml
@@ -1,0 +1,23 @@
+################################
+## Grafana ConfigMap
+#################################
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: "{{ .Release.Name }}-grafana-datasource"
+  labels:
+    tier: monitoring
+    component: grafana
+    release: {{ .Release.Name }}
+    workspace: {{ .Values.workspace }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+data:
+  datasource.yaml: |-
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        org_id: 1
+        url: "http://{{ .Release.Name }}-prometheus:9090"
+        access: proxy
+        is_default: true

--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -67,6 +67,9 @@ spec:
               port: {{ .Values.port }}
             initialDelaySeconds: 10
             periodSeconds: 10
+          volumeMounts:
+            - name: grafana-datasource-volume
+              mountPath: /etc/grafana/provisioning/datasources
           env:
             - name: GF_DATABASE_URL
               valueFrom:
@@ -75,5 +78,10 @@ spec:
                   key: connection
             - name: GF_AUTH_ANONYMOUS_ENABLED
               value: "true"
-            - name: ASTRO_DEFAULT_PROMETHEUS_HOST
-              value: "http://{{ .Release.Name }}-prometheus:9090"
+      volumes:
+        - name: grafana-datasource-volume
+          configMap:
+            name: "{{ .Release.Name }}-grafana-datasource"
+            items:
+              - key: datasource.yaml
+                path: datasource.yaml


### PR DESCRIPTION
Upgrades grafana to latest version.

This will rely on some changes that were just merged into the grafana image so deploying this from master without the updated image tag will fail.