### PR TITLE
Allow resources on containers to be overridden

### DIFF
--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -39,6 +39,8 @@ spec:
         - name: {{ .Release.Name }}-flower
           image: {{- include "flower_image" . | indent 1 }}
           args: ["airflow", "flower"]
+          resources:
+{{ toYaml .Values.flower.resources | indent 12 }}
           ports:
             - name: flower-ui
               containerPort: {{ .Values.ports.flowerUI }}

--- a/charts/airflow/templates/redis/redis-statefulset.yaml
+++ b/charts/airflow/templates/redis/redis-statefulset.yaml
@@ -32,6 +32,8 @@ spec:
         - name: {{ .Release.Name }}-redis
           image: {{- include "redis_image" . | indent 1 }}
           command: ["/bin/sh"]
+          resources:
+{{ toYaml .Values.redis.resources | indent 12 }}
           args: ["-c", "redis-server --requirepass ${REDIS_PASSWORD}"]
           ports:
             - name: redis-db

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -44,5 +44,7 @@ spec:
         - name: {{ .Release.Name }}-scheduler
           image: {{- include "airflow_image" . | indent 1 }}
           args: ["airflow", "scheduler"]
+          resources:
+{{ toYaml .Values.scheduler.resources | indent 12 }}
           env:
           {{- include "airflow_environment" . | indent 10 }}

--- a/charts/airflow/templates/statsd/statsd-deployment.yaml
+++ b/charts/airflow/templates/statsd/statsd-deployment.yaml
@@ -34,6 +34,8 @@ spec:
           image: {{- include "statsd_image" . | indent 1 }}
           args:
             - "-statsd.mapping-config=/etc/statsd-exporter/mappings.yml"
+          resources:
+{{ toYaml .Values.statsd.resources | indent 12 }}
           ports:
             - name: statsd-ingest
               protocol: UDP

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -39,6 +39,8 @@ spec:
         - name: {{ .Release.Name }}-webserver
           image: {{- include "airflow_image" . | indent 1 }}
           args: ["airflow", "webserver"]
+          resources:
+{{ toYaml .Values.webserver.resources | indent 12 }}
           ports:
             - name: webserver-ui
               containerPort: {{ .Values.ports.airflowUI }}

--- a/charts/airflow/templates/workers/worker-statefulset.yaml
+++ b/charts/airflow/templates/workers/worker-statefulset.yaml
@@ -42,6 +42,8 @@ spec:
         - name: {{ .Release.Name }}-worker
           image: {{- include "airflow_image" . | indent 1 }}
           args: ["airflow", "worker"]
+          resources:
+{{ toYaml .Values.workers.resources | indent 12 }}
           ports:
             - name: worker-logs
               containerPort: {{ .Values.ports.workerLogs }}

--- a/charts/airflow/values.yaml
+++ b/charts/airflow/values.yaml
@@ -21,6 +21,18 @@ images:
     name:  astronomerinc/ap-redis
     tag: 0.3.2
 
+# Environment variables for all airflow containers
+env:
+
+# Astronomer Airflow database config
+data:
+  airflowMetadataSecret: airflow-metadata
+  airflowResultBackendSecret: airflow-result-backend
+
+# Fernet key settings
+fernetKey: ~
+fernetKeySecretName: ~
+
 # Enable platform authentication
 auth:
   enabled: true
@@ -38,25 +50,60 @@ workers:
     # If using a custom storageClass, pass name ref to all statefulSets here
     storageClassName:
 
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
   # Grace period for tasks to finish after SIGTERM is sent from kubernetes
   terminationGracePeriodSeconds: 600
 
 # Airflow scheduler settings
 scheduler:
-
+  # Ensure we have one replica always running
   podDisruptionBudget:
-
-    # Ensure we have one replica always running
     maxUnavailable: 1
 
-# Environment variables for all airflow containers
-env:
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
-# Astronomer Airflow database config
-data:
-  airflowMetadataSecret: airflow-metadata
-  airflowResultBackendSecret: airflow-result-backend
-  # airflowBrokerSecret: airflow-broker
+# Airflow webserver settings
+webserver:
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+# Flower settings
+flower:
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+# Statsd settings
+statsd:
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 redis:
   terminationGracePeriodSeconds: 600
@@ -69,6 +116,14 @@ redis:
     # If using a custom storageClass, pass name ref to all statefulSets here
     storageClassName:
 
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
   # If set use as redis secret
   passwordSecretName: ~
   brokerURLSecretName: ~
@@ -76,9 +131,6 @@ redis:
   # Else, if password is set, create secret with it,
   # else generate a new one on install
   password: ~
-
-fernetKey: ~
-fernetKeySecretName: ~
 
 ports:
   flowerUI: 5555

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -32,6 +32,8 @@ spec:
       containers:
         - name: {{ .Release.Name }}-commander
           image: {{- include "commander_image" . | indent 1 }}
+          resources:
+{{ toYaml .Values.commander.resources | indent 12 }}
           ports:
             - name: commander-http
               containerPort: {{ .Values.ports.commanderHTTP }}

--- a/charts/astronomer/templates/houston/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/houston-deployment.yaml
@@ -51,6 +51,8 @@ spec:
       containers:
         - name: {{ .Release.Name }}-houston
           image: {{- include "houston_image" . | indent 1 }}
+          resources:
+{{ toYaml .Values.commander.resources | indent 12 }}
           {{- if .Values.global.tlsSecret }}
           volumeMounts:
             - name: registry-tls-volume

--- a/charts/astronomer/templates/orbit/orbit-deployment.yaml
+++ b/charts/astronomer/templates/orbit/orbit-deployment.yaml
@@ -29,6 +29,8 @@ spec:
       containers:
         - name: {{ .Release.Name }}-orbit
           image: {{- include "orbit_image" . | indent 1 }}
+          resources:
+{{ toYaml .Values.orbit.resources | indent 12 }}
           ports:
             - name: orbit-http
               containerPort: {{ .Values.ports.orbitHTTP }}
@@ -45,5 +47,9 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
           env:
+            {{- range $i, $config := .Values.orbit.env }}
+            - name: {{ $config.name }}
+              value: {{ $config.value | quote }}
+            {{- end }}
             - name: APP_API_LOC_HTTPS
               value: "https://houston.{{ .Values.global.baseDomain }}/v1"

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -32,6 +32,8 @@ spec:
       containers:
         - name: {{ .Release.Name }}-registry
           image: {{- include "registry_image" . | indent 1 }}
+          resources:
+{{ toYaml .Values.registry.resources | indent 12 }}
           volumeMounts:
             - name: registry-config-volume
               mountPath: /etc/docker/registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -38,19 +38,53 @@ auth:
     clientId: ~
     clientSecret: ~
 
+orbit:
+  env: {}
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
 houston:
-  env:
+  env: {}
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
 commander:
-  env:
+  env: {}
+  resources: {}
+   # limits:
+   #  cpu: 100m
+   #  memory: 128Mi
+   # requests:
+   #  cpu: 100m
+   #  memory: 128Mi
 
 registry:
-  # Enable persistence to keep registry data between deploys
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
   persistence:
+    # Enable persistent storage
     enabled: true
+    # Size of volume to provision
     size: 50Gi
     # If using a custom storageClass, pass name ref to all statefulSets here
     storageClassName:
+
   auth:
     service: "docker-registry"
     issuer: "houston"

--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -52,6 +52,8 @@ spec:
       containers:
         - name: "{{ .Release.Name }}-grafana"
           image: {{- include "grafana_image" . | indent 1 }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
           ports:
             - name: grafana-ui
               containerPort: {{ .Values.port }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -15,3 +15,11 @@ grafanaBackendSecret: grafana-backend
 bootstrapDatabase: true
 
 port: 3000
+
+resources: {}
+#  limits:
+#   cpu: 100m
+#   memory: 128Mi
+#  requests:
+#   cpu: 100m
+#   memory: 128Mi

--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -31,6 +31,8 @@ spec:
       containers:
         - name: {{ .Release.Name }}-nginx
           image: {{- include "nginx_image" . | indent 1 }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
           args:
             - /nginx-ingress-controller
             - --default-backend-service={{ .Release.Namespace }}/{{ .Release.Name }}-nginx-default-backend

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,6 +9,14 @@ images:
     name: astronomerinc/ap-default-backend
     tag: 0.3.2
 
+resources: {}
+#  limits:
+#   cpu: 100m
+#   memory: 128Mi
+#  requests:
+#   cpu: 100m
+#   memory: 128Mi
+
 # AntiAffinity can be "hard" or "soft"
 antiAffinity: "soft"
 

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -38,6 +38,8 @@ spec:
       containers:
         - name: "{{ .Release.Name }}-prometheus"
           image: {{- include "prometheus_image" . | indent 1 }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
           args:
             - "--config.file=/etc/prometheus/config/prometheus.yaml"
             - "--storage.tsdb.path={{ .Values.dataDir }}"

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -7,6 +7,14 @@ images:
     name: astronomerinc/ap-prometheus
     tag: 0.3.2
 
+resources: {}
+#  limits:
+#   cpu: 100m
+#   memory: 128Mi
+#  requests:
+#   cpu: 100m
+#   memory: 128Mi
+
 dataDir: "/prometheus"
 
 # Enable persistence for Prometheus

--- a/config.tpl.yaml
+++ b/config.tpl.yaml
@@ -8,7 +8,26 @@ global:
   tlsSecret:
   acme: false
 
+astronomer:
+  orbit:
+    resources: {}
+
+  houston:
+    resources: {}
+
+  commander:
+    resources: {}
+
+  registry:
+    resources: {}
+
 nginx:
+  resources: {}
   loadBalancerIP:
   loadBalancerSourceRanges:
-  - 0.0.0.0/0
+
+grafana:
+  resources: {}
+
+prometheus:
+  resources: {}

--- a/values.yaml
+++ b/values.yaml
@@ -53,16 +53,6 @@ global:
       enabled: true
 
 #################################
-## Nginx configuration
-#################################
-nginx:
-  # IP address the nginx ingress should bind to
-  loadBalancerIP:
-
-  # Used to restrict IPs which can reach the nginx ingress
-  loadBalancerSourceRanges:
-
-#################################
 ## Astronomer configuration
 #################################
 astronomer:
@@ -77,3 +67,28 @@ astronomer:
 
   registry:
     resources: {}
+
+#################################
+## Nginx configuration
+#################################
+nginx:
+  resources: {}
+
+  # IP address the nginx ingress should bind to
+  loadBalancerIP:
+
+  # Used to restrict IPs which can reach the nginx ingress
+  loadBalancerSourceRanges:
+
+
+#################################
+## Grafana configuration
+#################################
+grafana:
+  resources: {}
+
+#################################
+## Prometheus configuration
+#################################
+prometheus:
+  resources: {}

--- a/values.yaml
+++ b/values.yaml
@@ -63,39 +63,17 @@ nginx:
   loadBalancerSourceRanges:
 
 #################################
-## Airflow configuration
-#################################
-airflow:
-  # Worker settings
-  workers:
-    # Enable persistence to keep logs around between deploys
-    persistence:
-      enabled: true
-      size: 10Gi
-      # If using a custom storageClass, pass name ref to all statefulSets here
-      storageClassName:
-  prometheus:
-    persistence:
-      enabled: true
-      size: 50Gi
-      # If using a custom storageClass, pass name ref to all statefulSets here
-      storageClassName:
-
-#################################
 ## Astronomer configuration
 #################################
 astronomer:
+  orbit:
+    resources: {}
+
+  houston:
+    resources: {}
+
+  commander:
+    resources: {}
+
   registry:
-    # Enable persistence to keep registry data between deploys
-    persistence:
-      enabled: true
-      size: 50Gi
-      # If using a custom storageClass, pass name ref to all statefulSets here
-      storageClassName:
-  auth:
-    local:
-      enabled: true
-    google:
-      enabled: false
-      clientId: ~
-      clientSecret: ~
+    resources: {}


### PR DESCRIPTION
This PR adds a `resources` object to all `values.yaml`s and templates any values into the corresponding containers.

By default, this should have zero effect. It does allow us to override any values at install time using a `config.yaml` though. By leaving the default behavior the same, we can continue to easily run on low resource environments, like a single node/laptop. As we do more deploys we should keep track of how we're setting these values in production environment. We can start to build some example configs for some nice T-shirt sizes to ship along.