### PR TITLE
Add platform release name to airflow labels

### DIFF
--- a/charts/airflow/templates/flower/flower-deployment.yaml
+++ b/charts/airflow/templates/flower/flower-deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     tier: airflow
     component: flower
     release: {{ .Release.Name }}
+    platform: {{ .Values.platform.release }}
     workspace: {{ .Values.platform.workspace | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
@@ -20,6 +21,7 @@ spec:
       tier: airflow
       component: flower
       release: {{ .Release.Name }}
+      platform: {{ .Values.platform.release }}
       workspace: {{ .Values.platform.workspace | quote }}
   template:
     metadata:
@@ -27,6 +29,7 @@ spec:
         tier: airflow
         component: flower
         release: {{ .Release.Name }}
+        platform: {{ .Values.platform.release }}
         workspace: {{ .Values.platform.workspace | quote }}
     spec:
       restartPolicy: Always

--- a/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/charts/airflow/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     tier: airflow
     component: pgbouncer
     release: {{ .Release.Name }}
+    platform: {{ .Values.platform.release }}
     workspace: {{ .Values.platform.workspace | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
@@ -23,6 +24,7 @@ spec:
       tier: airflow
       component: pgbouncer
       release: {{ .Release.Name }}
+      platform: {{ .Values.platform.release }}
       workspace: {{ .Values.platform.workspace | quote }}
   template:
     metadata:
@@ -30,6 +32,7 @@ spec:
         tier: airflow
         component: pgbouncer
         release: {{ .Release.Name }}
+        platform: {{ .Values.platform.release }}
         workspace: {{ .Values.platform.workspace | quote }}
       annotations:
         checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }} 

--- a/charts/airflow/templates/redis/redis-statefulset.yaml
+++ b/charts/airflow/templates/redis/redis-statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
     tier: airflow
     component: redis
     release: {{ .Release.Name }}
+    platform: {{ .Values.platform.release }}
     workspace: {{ .Values.platform.workspace | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
@@ -20,6 +21,7 @@ spec:
       tier: airflow
       component: redis
       release: {{ .Release.Name }}
+      platform: {{ .Values.platform.release }}
       workspace: {{ .Values.platform.workspace | quote }}
   template:
     metadata:
@@ -27,6 +29,7 @@ spec:
         tier: airflow
         component: redis
         release: {{ .Release.Name }}
+        platform: {{ .Values.platform.release }}
         workspace: {{ .Values.platform.workspace | quote }}
     spec:
       containers:

--- a/charts/airflow/templates/scheduler/scheduler-deployment.yaml
+++ b/charts/airflow/templates/scheduler/scheduler-deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     tier: airflow
     component: scheduler
     release: {{ .Release.Name }}
+    platform: {{ .Values.platform.release }}
     workspace: {{ .Values.platform.workspace | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
@@ -24,6 +25,7 @@ spec:
       tier: airflow
       component: scheduler
       release: {{ .Release.Name }}
+      platform: {{ .Values.platform.release }}
       workspace: {{ .Values.platform.workspace | quote }}
       local: {{ $local | quote }}
   template:
@@ -32,6 +34,7 @@ spec:
         tier: airflow
         component: scheduler
         release: {{ .Release.Name }}
+        platform: {{ .Values.platform.release }}
         workspace: {{ .Values.platform.workspace | quote }}
         local: {{ $local | quote }}
       annotations:

--- a/charts/airflow/templates/statsd/statsd-deployment.yaml
+++ b/charts/airflow/templates/statsd/statsd-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     tier: airflow
     component: statsd
     release: {{ .Release.Name }}
+    platform: {{ .Values.platform.release }}
     workspace: {{ .Values.platform.workspace | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
@@ -19,6 +20,7 @@ spec:
       tier: airflow
       component: statsd
       release: {{ .Release.Name }}
+      platform: {{ .Values.platform.release }}
       workspace: {{ .Values.platform.workspace | quote }}
   template:
     metadata:
@@ -26,6 +28,7 @@ spec:
         tier: airflow
         component: statsd
         release: {{ .Release.Name }}
+        platform: {{ .Values.platform.release }}
         workspace: {{ .Values.platform.workspace | quote }}
     spec:
       restartPolicy: Always

--- a/charts/airflow/templates/webserver/webserver-deployment.yaml
+++ b/charts/airflow/templates/webserver/webserver-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
     tier: airflow
     component: webserver
     release: {{ .Release.Name }}
+    platform: {{ .Values.platform.release }}
     workspace: {{ .Values.platform.workspace | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
@@ -19,6 +20,7 @@ spec:
       tier: airflow
       component: webserver
       release: {{ .Release.Name }}
+      platform: {{ .Values.platform.release }}
       workspace: {{ .Values.platform.workspace | quote }}
   template:
     metadata:
@@ -26,6 +28,7 @@ spec:
         tier: airflow
         component: webserver
         release: {{ .Release.Name }}
+        platform: {{ .Values.platform.release }}
         workspace: {{ .Values.platform.workspace | quote }}
       annotations:
         checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }} 

--- a/charts/airflow/templates/workers/worker-statefulset.yaml
+++ b/charts/airflow/templates/workers/worker-statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
     tier: airflow
     component: worker
     release: {{ .Release.Name }}
+    platform: {{ .Values.platform.release }}
     workspace: {{ .Values.platform.workspace | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
@@ -22,6 +23,7 @@ spec:
       tier: airflow
       component: worker
       release: {{ .Release.Name }}
+      platform: {{ .Values.platform.release }}
       workspace: {{ .Values.platform.workspace | quote }}
   template:
     metadata:
@@ -29,6 +31,7 @@ spec:
         tier: airflow
         component: worker
         release: {{ .Release.Name }}
+        platform: {{ .Values.platform.release }}
         workspace: {{ .Values.platform.workspace | quote }}
       annotations:
         checksum/metadata-secret: {{ include (print $.Template.BasePath "/secrets/metadata-connection-secret.yaml") . | sha256sum }}


### PR DESCRIPTION
Added the platform release name to the airflow labels of all deployments and stateful sets.  This is necessary for more efficient filtering of pods that will be watched for status