### PR TITLE
Add support for airflow 1.10 celery_backend config

### DIFF
--- a/charts/airflow/templates/_helpers.yaml
+++ b/charts/airflow/templates/_helpers.yaml
@@ -63,7 +63,7 @@
         name: {{ template "airflow_metadata_secret" . }}
         key: connection
   {{- if eq .Values.executor "CeleryExecutor" }}
-  - name: AIRFLOW__CELERY__CELERY_RESULT_BACKEND
+  - name: {{if eq .Values.airflowVersion "1.9.0" }} AIRFLOW__CELERY__CELERY_RESULT_BACKEND {{ else }} AIRFLOW__CELERY__RESULT_BACKEND {{ end }}
     valueFrom:
       secretKeyRef:
         name: {{ template "airflow_result_backend_secret" . }}


### PR DESCRIPTION
This PR adds support for the latest breaking change with the celery result backend config.

Tested with `helm install . --debug --dry-run`