### PR TITLE
Extend initialDelay to allow prometheus more time to reboot/boot

### DIFF
--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -60,15 +60,15 @@ spec:
               containerPort: {{ .Values.ports.http }}
           livenessProbe:
             httpGet:
-              path: /graph
+              path: /api/v1/status/config
               port: {{ .Values.ports.http }}
-            initialDelaySeconds: 10
+            initialDelaySeconds: 90
             periodSeconds: 10
           readinessProbe:
             httpGet:
-              path: /graph
+              path: /api/v1/status/config
               port: {{ .Values.ports.http }}
-            initialDelaySeconds: 10
+            initialDelaySeconds: 90
             periodSeconds: 10
       volumes:
         - name: prometheus-config-volume


### PR DESCRIPTION
This PR should resolve issues we have been seeing where the Prometheus /graph endpoint becomes bogged down.

We now allow for a longer reboot cycle as well as using what should be a faster endpoint for a healthcheck until Prometheus implements /health and /ready